### PR TITLE
Update example match OAuth client configs

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -13,7 +13,7 @@
                 messageDiv.innerHTML = identity.user_name;
 
                 //Get accessToken since new user logged in
-                var tokenPromise = Singular.access('cloud_controller.read');
+                var tokenPromise = Singular.access('openid');
                 tokenPromise
                     .then(function(token){
                         messageDiv.innerHTML += '<br/>access_token=' + token;


### PR DESCRIPTION
https://github.com/cloudfoundry/uaa-singular#server-side-prerequisites only mentions `openid` while example uses `cloud_controller.read` - only `openid` is actually required, so the example should request `openid` instead of `cloud_controller.read`