### PR TITLE
Update Redirect URL and README for login flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ Singular requires a configured OAuth client in the UAA which requires at least t
 | `authorized_grant_types` |  `implicit`  |
 |          `scope`         | `["openid"]` |
 |       `autoapprove`      | `["openid"]` |
-|       `redirect_uri`     | `[ "http://<singular-domain>/postauth.html","http://<singular-domain>/postaccess.html" ]` |
+|       `redirect_uri`     | `[ "http://<singular-domain>/PATH/TO/SINGULAR/postauth.html","http://<singular-domain>/PATH/TO/SINGULAR/postaccess.html" ]` |
+
+For the example `index.html`, you will also need to add `http://<singular-domain>/index.html` to the `redirect_uri` configuration.
 
 ### UAA version compatibility
 

--- a/example/index.html
+++ b/example/index.html
@@ -24,7 +24,10 @@
             },
             onLogout: function () {
                 console.log('User logged out');
-                messageDiv.innerHTML = 'Click <a href="' + Singular.properties.uaaLocation + '" target="_blank">here</a> to log in';
+                //Using a standard OAuth redirect to implement an initial login behavior that redirects back to the application
+                //This is optional as UAA Singular can detect logins that occur in other browser tabs
+                var loginRedirectUrl = Singular.properties.uaaLocation + '/oauth/authorize?response_type=id_token&client_id=' + Singular.properties.clientId + '&redirect_uri=' + window.location.href;
+                messageDiv.innerHTML = 'Click <a href="' + loginRedirectUrl + '">here</a> to log in';
             }
         });
     </script>


### PR DESCRIPTION
Changed login URL to showcase a redirect back to app. This is not part of the original behavior since Singular detects logins from other tabs. Left comments that this redirect is purely cosmetic (ID token from this flow can be ignored).

Updated readme for new redirect path back to index.html, and also noted in readme that path to singular must change. This should be revisited when looking at how to allow configurable paths to UAA singular NPM module.