### PR TITLE
Replace Cargo Gradle tasks with bootRun in UAA test harness

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build": "rm -rf singular && webpack",
     "get-uaa": "rm -rf test/tmp/uaa && git clone -b develop https://github.com/cloudfoundry/uaa.git test/tmp/uaa",
     "start-uaa": "sh test/startUAA.sh",
-    "stop-uaa": "cd test/tmp/uaa && ./gradlew cargoStopLocal",
+    "stop-uaa": "cd test/tmp/uaa && ./scripts/kill_uaa.sh",
     "start-singular-app": "sh test/startHttpServer.sh",
     "stop-singular-app": "kill $(cat test/tmp/httpServer.pid.tmp) && rm test/tmp/httpServer.pid.tmp",
     "test": "npm run build && npm run unit-test && npm run integration-test",

--- a/test/startUAA.sh
+++ b/test/startUAA.sh
@@ -3,7 +3,7 @@
 set -ex
 
 cd test/tmp/uaa
-./gradlew cargoStartLocal 2>&1 > /dev/null
+./gradlew run 2>&1 > /dev/null &
 
 START_TIME_IN_SEC=$(date +%s)
 UAA_START_TIMEOUT_SEC=600


### PR DESCRIPTION
## Summary
- UAA no longer uses the Gradle Cargo plugin, so `npm run start-uaa` / `npm run stop-uaa` were broken: `cargoStartLocal`/`cargoStopLocal` no longer exist.
- `test/startUAA.sh`: replace `./gradlew cargoStartLocal` with `./gradlew run &`. UAA's `run` task kills any stale UAA process then runs `bootRun`. It's backgrounded because, unlike the old Cargo deploy task, `bootRun` blocks in the foreground until killed — without `&` the script would hang before ever reaching the readiness poll / test-client creation.
- `package.json`: replace `stop-uaa`'s `./gradlew cargoStopLocal` with UAA's own `./scripts/kill_uaa.sh`, which looks up the `UaaBootApplication` process via `jps` (falling back to killing whatever's on port 8080).

## Test plan
- [x] `npm run start-uaa` — UAA boots, OAuth token fetched, `singular-test-client` created
- [x] `npm run start-singular-app` — static bundle served
- [x] `npm run unit-test` — 25 specs, 0 failures
- [x] `npm run integration-test` (Nightwatch) — 56/56 assertions passed (Access Tests + Identity Tests)
- [x] `npm run stop-uaa` / `stop-singular-app` — both processes cleaned up correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)