### PR TITLE
Add GitHub Actions workflow for PR integration tests against UAA

### DIFF
--- a/.github/workflows/pull-request-integration.yml
+++ b/.github/workflows/pull-request-integration.yml
@@ -1,8 +1,12 @@
 name: pull-request-integration-tests
 
 on:
+  push:
+    branches: [ "main" ]
   pull_request:
-    branches: [main]
+    branches: [ "main" ]
+  schedule:
+    - cron: '30 7 * * *'
 
 permissions:
   contents: read

--- a/.github/workflows/pull-request-integration.yml
+++ b/.github/workflows/pull-request-integration.yml
@@ -1,0 +1,99 @@
+name: pull-request-integration-tests
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  uaa-singular-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout uaa-singular
+        uses: actions/checkout@v4
+
+      - name: Checkout cloudfoundry/uaa (develop)
+        uses: actions/checkout@v4
+        with:
+          repository: cloudfoundry/uaa
+          ref: develop
+          path: uaa
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '25'
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('uaa/**/*.gradle*', 'uaa/gradle/wrapper/gradle-wrapper.properties') }}
+
+      - name: Build UAA bootWar
+        working-directory: uaa
+        run: ./gradlew bootWar
+
+      - name: Start UAA
+        working-directory: uaa
+        run: |
+          nohup java \
+            -DCLOUDFOUNDRY_CONFIG_PATH=scripts/boot \
+            -DSECRETS_DIR=scripts/boot \
+            -Dserver.servlet.context-path=/uaa \
+            -Dsmtp.host=localhost \
+            -Dsmtp.port=2525 \
+            -Dspring.profiles.active=hsqldb \
+            -Djava.security.egd=file:/dev/./urandom \
+            -jar uaa/build/libs/cloudfoundry-identity-uaa-0.0.0.war > uaa-boot.log 2>&1 &
+
+          echo "Waiting for UAA to be ready..."
+          for i in $(seq 1 120); do
+            if curl -sf http://localhost:8080/uaa > /dev/null 2>&1; then
+              echo "UAA is now running"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "UAA failed to start within 600 seconds. Boot log:"
+          cat uaa-boot.log
+          exit 1
+
+      - name: Create singular-test-client
+        run: |
+          ACCESS_TOKEN=$(curl -sf http://localhost:8080/uaa/oauth/token -X POST \
+            -H 'Content-Type: application/x-www-form-urlencoded' \
+            -H 'Accept: application/json' \
+            -d 'client_id=admin&client_secret=adminsecret&grant_type=client_credentials&token_format=opaque&response_type=token' \
+            | jq -r '.access_token')
+
+          curl -sf http://localhost:8080/uaa/oauth/clients -X POST \
+            -H 'Content-Type: application/json' \
+            -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+            -H 'Accept: application/json' \
+            -d '{
+              "scope": ["cloud_controller.read", "cloud_controller.write", "openid"],
+              "client_id": "singular-test-client",
+              "resource_ids": [],
+              "authorized_grant_types": ["implicit"],
+              "redirect_uri": ["http://localhost:8000/**"],
+              "autoapprove": true,
+              "name": "Singular Test Client"
+            }'
+
+      - name: Install dependencies and matching chromedriver
+        run: |
+          npm install
+          CHROME_MAJOR=$(google-chrome --version | grep -oP '\d+' | head -1)
+          npm install "chromedriver@${CHROME_MAJOR}"
+
+      - name: Start singular app
+        run: npm run start-singular-app
+
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/pull-request-integration.yml
+++ b/.github/workflows/pull-request-integration.yml
@@ -4,12 +4,17 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   uaa-singular-tests:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout uaa-singular
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Checkout cloudfoundry/uaa (develop)
         uses: actions/checkout@v4
@@ -17,6 +22,7 @@ jobs:
           repository: cloudfoundry/uaa
           ref: develop
           path: uaa
+          persist-credentials: false
 
       - uses: actions/setup-java@v4
         with:
@@ -42,6 +48,7 @@ jobs:
       - name: Start UAA
         working-directory: uaa
         run: |
+          WAR_FILE=$(ls uaa/build/libs/*.war | head -1)
           nohup java \
             -DCLOUDFOUNDRY_CONFIG_PATH=scripts/boot \
             -DSECRETS_DIR=scripts/boot \
@@ -50,7 +57,7 @@ jobs:
             -Dsmtp.port=2525 \
             -Dspring.profiles.active=hsqldb \
             -Djava.security.egd=file:/dev/./urandom \
-            -jar uaa/build/libs/cloudfoundry-identity-uaa-0.0.0.war > uaa-boot.log 2>&1 &
+            -jar "${WAR_FILE}" > uaa-boot.log 2>&1 &
 
           echo "Waiting for UAA to be ready..."
           for i in $(seq 1 120); do
@@ -88,9 +95,9 @@ jobs:
 
       - name: Install dependencies and matching chromedriver
         run: |
-          npm install
+          npm ci
           CHROME_MAJOR=$(google-chrome --version | grep -oP '\d+' | head -1)
-          npm install "chromedriver@${CHROME_MAJOR}"
+          npm install "chromedriver@${CHROME_MAJOR}" --no-save
 
       - name: Start singular app
         run: npm run start-singular-app

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,6 +1,6 @@
 name: unit-test
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,12 +1,16 @@
 name: unit-test
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - run: npm install
     - name: Build
       run: npm run build


### PR DESCRIPTION
## Summary
Ports the Concourse `uaa-singular-tests` job (`concourse/pull-requests/pipeline.yml` in `uaa-ci`) to a self-contained GitHub Actions workflow (`.github/workflows/pull-request-integration.yml`) that runs on every pull request:

1. Checks out this PR and `cloudfoundry/uaa` (`develop`, public repo — no deploy key needed)
2. Builds UAA's `bootWar` and boots it, polling `/uaa` for readiness
3. Creates the `singular-test-client` OAuth client via the admin API (same payload the Concourse task and local `test/startUAA.sh` use)
4. Installs deps, then installs a `chromedriver` version matching the runner's Chrome major version at runtime (same pattern the existing Concourse task already uses — never commit a pinned/downgraded version)
5. Starts the static app server and runs `npm test` (build + unit + Nightwatch integration)

Differences from the Concourse version, and why:
- No dependency on the private `uaa-ci` repo for the shared task script — the logic is inlined directly, since a public-repo `pull_request` workflow (including fork PRs) shouldn't depend on a private repo.
- No explicit PR status `put` steps — GitHub Actions reports the job's pass/fail as the PR check natively.
- No `privileged: true` container — `nightwatch.json` already runs Chrome with `--no-sandbox`, and GitHub's `ubuntu-latest` runners ship Chrome preinstalled.
- Uses `pull_request` (not `pull_request_target`): runs with the fork's code and no repo secrets, since none are needed for this job.

Also adds `pull_request` to `unit-test.yml`'s trigger (alongside the existing `push`). `push`-triggered workflows only run in a fork's own Actions context, not upstream, so external contributors' PRs currently get no build/unit-test check at all. Same-repo branches will now run that job twice per commit once a PR is open (`push` + `pull_request`) — an accepted, minor cost for a job this cheap.

## Test plan
- [x] Confirm both workflows run successfully on this PR (validates the full UAA build/boot/test flow works in GitHub Actions, and that unit-test now triggers on pull_request)
- [x] Manually verified the equivalent local flow (build UAA, boot via gradlew, create test client, `npm test`) succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)